### PR TITLE
Warn when detecting running Minecraft processes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,11 @@ if build_machine.system() == 'windows'
       include_directories : include_directories('resource', 'C:/msys64/mingw64/include/wx-3.0')
     )
   ]
-  msw_extra_deps = [meson.get_compiler('cpp').find_library('ws2_32')]
+  msw_extra_deps = [
+    meson.get_compiler('cpp').find_library('ws2_32'),
+    meson.get_compiler('cpp').find_library('ole32'),
+    meson.get_compiler('cpp').find_library('wbemuuid')
+  ]
   wxwidgets_mods = ['--static']
   main_link_args = ['-static']
 endif

--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,15 @@ major_version = version_array[0].to_int()
 minor_version = version_array[1].to_int()
 patch_version = version_array[2].to_int()
 
+#################
+# Linux Options #
+#################
+
+lnx_extra_deps = []
+if build_machine.system() == 'linux'
+  lnx_extra_deps = [meson.get_compiler('cpp').find_library('libprocps')]
+endif
+
 ###################
 # Windows Options #
 ###################
@@ -111,6 +120,7 @@ trollauncher_srcs = [
     'trollauncher/keeplist_processor.cpp',
     'trollauncher/launcher_profiles_editor.cpp',
     'trollauncher/main.cpp',
+    'trollauncher/mc_process_detector.cpp',
     'trollauncher/modpack_installer.cpp',
     'trollauncher/utils.cpp'
 ]
@@ -126,6 +136,6 @@ trollauncher_deps = [
 executable(
   'trollauncher', trollauncher_srcs + msw_extra_src,
   include_directories : [],
-  dependencies : trollauncher_deps + msw_extra_deps,
+  dependencies : trollauncher_deps + lnx_extra_deps + msw_extra_deps,
   link_args : main_link_args
 )

--- a/trollauncher/cli.cpp
+++ b/trollauncher/cli.cpp
@@ -447,11 +447,11 @@ std::string GetProcessRunningMessage(McProcessRunning process_running)
 {
   switch (process_running) {
   case McProcessRunning::LAUNCHER:
-    return "The Minecraft Launcher is running, please close it";
+    return "The Minecraft Launcher appears to be running, please close it";
   case McProcessRunning::GAME:
-    return "Minecraft is running, please close it";
+    return "Minecraft appears to be running, please close it";
   case McProcessRunning::LAUNCHER_AND_GAME:
-    return "The Minecraft Launcher and game are both running, please close both";
+    return "The Minecraft Launcher and game both appear to be running, please close them";
   default:
     // We should never actaully display this
     return "Durp! Durp! Durp!";

--- a/trollauncher/gui.cpp
+++ b/trollauncher/gui.cpp
@@ -163,7 +163,8 @@ bool GuiApp::OnInit()
   frame_ptr->Show(true);
   const McProcessRunning process_running = McProcessDetector::GetRunningMinecraft();
   if (process_running != McProcessRunning::NONE) {
-    const auto text = GetProcessRunningMessage(process_running, false);
+    const auto text = wxString::Format("Detected running Minecraft processes!\n\n%s",
+                                       GetProcessRunningMessage(process_running, false));
     wxMessageBox(text, "Error", wxOK | wxICON_ERROR, frame_ptr);
     return false;
   }
@@ -241,7 +242,8 @@ void GuiFrame::OnDoModpackInstall(wxCommandEvent&)
   }
   const McProcessRunning process_running = McProcessDetector::GetRunningMinecraft();
   if (process_running != McProcessRunning::NONE) {
-    const auto text = GetProcessRunningMessage(process_running, true);
+    const auto text = wxString::Format("Detected running Minecraft processes!\n\n%s",
+                                       GetProcessRunningMessage(process_running, true));
     wxMessageBox(text, "Error", wxOK | wxICON_ERROR, this);
     return;
   }
@@ -293,7 +295,8 @@ void GuiFrame::OnDoModpackUpdate(wxCommandEvent&)
   }
   const McProcessRunning process_running = McProcessDetector::GetRunningMinecraft();
   if (process_running != McProcessRunning::NONE) {
-    const auto text = GetProcessRunningMessage(process_running, true);
+    const auto text = wxString::Format("Detected running Minecraft processes!\n\n%s",
+                                       GetProcessRunningMessage(process_running, true));
     wxMessageBox(text, "Error", wxOK | wxICON_ERROR, this);
     return;
   }
@@ -567,19 +570,15 @@ GuiDialogProgress::GuiDialogProgress(wxWindow* parent)
 
 std::string GetProcessRunningMessage(McProcessRunning process_running, bool can_continue)
 {
+  const std::string continue_text = (can_continue ? "to continue." : "and restart this utility.");
   switch (process_running) {
   case McProcessRunning::LAUNCHER:
-    return std::string("Detected a running Minecraft Launcher.\n\n")
-           + (can_continue ? "Please close the launcher to continue."
-                           : "Please close the launcher and restart this utility.");
+    return "The Minecraft Launcher appears to be running. Please close it " + continue_text;
   case McProcessRunning::GAME:
-    return std::string("Detected a running Minecraft game (Java).\n\n")
-           + (can_continue ? "Please close the game to continue."
-                           : "Please close the game and restart this utility.");
+    return "Minecraft appears to be running. Please close it " + continue_text;
   case McProcessRunning::LAUNCHER_AND_GAME:
-    return std::string("Detected a running Minecraft Launcher and game (Java).\n\n")
-           + (can_continue ? "Please close the launcher and game to continue."
-                           : "Please close the launcher and game and restart this utility.");
+    return "The Minecraft Launcher and game both appear to be running. Please close them "
+           + continue_text;
   default:
     // We should never actaully display this
     return "Durp! Durp! Durp!";

--- a/trollauncher/java_detector.cpp
+++ b/trollauncher/java_detector.cpp
@@ -132,7 +132,7 @@ std::optional<std::string> GetJavaVersion(const fs::path& java_path)
   // java version "1.8.0_51"
   // openjdk version "11.0.5" 2019-10-15
   std::smatch version_match;
-  static const std::regex version_regex("^[^ ]+ version \"([^\"]+)\"");
+  const std::regex version_regex("^[^ ]+ version \"([^\"]+)\"");
   if (!std::regex_search(java_output, version_match, version_regex)) {
     return std::nullopt;
   }

--- a/trollauncher/mc_process_detector.cpp
+++ b/trollauncher/mc_process_detector.cpp
@@ -18,7 +18,6 @@
 
 #include "trollauncher/mc_process_detector.hpp"
 
-#include <iostream>
 #include <regex>
 
 #ifndef ITS_A_UNIX_SYSTEM
@@ -32,7 +31,11 @@
 #if ITS_A_UNIX_SYSTEM
 #include <proc/readproc.h>
 #else
-// TODO
+#define _WIN32_DCOM
+#include <comutil.h>
+#include <wbemidl.h>
+#include <windows.h>
+#include "TlHelp32.h"
 #endif
 
 namespace tl {
@@ -70,9 +73,93 @@ void ForEachProcesses(const std::function<bool(const std::string&)>& func)
   closeproc(proctab_ptr);
 }
 #else
-void ForEachProcesses(const std::function<bool(const std::string&)>&)
+std::optional<std::string> StringFromBSTR(const _bstr_t& bstr)
 {
-  // TODO
+  if (bstr.length() == 0) {
+    return "";
+  }
+  const int wide_len = SysStringLen(bstr);
+  const int req_len = WideCharToMultiByte(CP_UTF8, 0, bstr, wide_len, nullptr, 0, nullptr, nullptr);
+  if (req_len == 0) {
+    return std::nullopt;
+  }
+  std::string str(req_len, '\0');
+  const int str_len =
+      WideCharToMultiByte(CP_UTF8, 0, bstr, wide_len, str.data(), req_len, nullptr, nullptr);
+  if (str_len == 0) {
+    return std::nullopt;
+  }
+  return str;
+}
+
+class ScopedExiter {
+ public:
+  ScopedExiter(const std::function<void()>& func) : func_(func) {}
+  ~ScopedExiter()
+  {
+    func_();
+  }
+
+ private:
+  std::function<void()> func_;
+};
+
+void ForEachProcesses(const std::function<bool(const std::string&)>& func)
+{
+  // This only needs to be done once per thread, but it's also ok to do it
+  // multiple times, which is what we do here. The problem is when it's called
+  // with a different concurrency model, which seems to happen with wxWidgets.
+  // In that case, we don't care if it fails.
+  const HRESULT hr_init = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+  if (FAILED(hr_init) && hr_init != RPC_E_CHANGED_MODE) {
+    return;
+  }
+  const ScopedExiter uninitializer([]() { CoUninitialize(); });
+  // This is supposed to be called exactly once. So if it's already been called,
+  // detect that and just ignore the error.
+  const HRESULT hr_init_sec =
+      CoInitializeSecurity(nullptr, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT,
+                           RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE, nullptr);
+  if (FAILED(hr_init_sec) && hr_init_sec != RPC_E_TOO_LATE) {
+    return;
+  }
+  IWbemLocator* wbem_locator = nullptr;
+  if (FAILED(CoCreateInstance(CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER, IID_IWbemLocator,
+                              reinterpret_cast<LPVOID*>(&wbem_locator)))) {
+    return;
+  }
+  const ScopedExiter wbem_locator_releaser([&]() { wbem_locator->Release(); });
+  IWbemServices* wbem_services = nullptr;
+  if (FAILED(wbem_locator->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0,
+                                         nullptr, nullptr, &wbem_services))) {
+    return;
+  }
+  const ScopedExiter wbem_services_releaser([&]() { wbem_services->Release(); });
+  IEnumWbemClassObject* enum_wbem = nullptr;
+  if (FAILED(wbem_services->ExecQuery(_bstr_t(L"WQL"),
+                                      _bstr_t(L"SELECT CommandLine FROM Win32_Process"),
+                                      WBEM_FLAG_FORWARD_ONLY, nullptr, &enum_wbem))) {
+    return;
+  }
+  const ScopedExiter enum_wbem_releaser([&]() { enum_wbem->Release(); });
+  IWbemClassObject* wbem_object = nullptr;
+  ULONG num_objects = 0;
+  // Don't use SUCCEEDED here, but specifically check for S_OK
+  while (enum_wbem->Next(static_cast<long>(WBEM_INFINITE), 1, &wbem_object, &num_objects) == S_OK) {
+    if (num_objects == 0) {
+      continue;
+    }
+    const ScopedExiter wbem_object_releaser([&]() { wbem_object->Release(); });
+    _variant_t command_line_var;
+    if (FAILED(wbem_object->Get(L"CommandLine", 0, &command_line_var, nullptr, nullptr))
+        || command_line_var.vt != VT_BSTR) {
+      continue;
+    }
+    const std::string command_line = *StringFromBSTR(static_cast<_bstr_t>(command_line_var));
+    if (!func(command_line)) {
+      break;
+    }
+  }
 }
 #endif
 
@@ -85,7 +172,9 @@ McProcessRunning McProcessDetector::GetRunningMinecraft()
   // slightly wacky like using a relative path, this will fail. This is still
   // kind of the best option because matching just "minecraft-launcher" is a bit
   // generic and might give false positives.
-  const std::regex launcher_regex("^\\/opt\\/minecraft-launcher\\/minecraft-launcher");
+  const std::regex launcher_regex(ITS_A_UNIX_SYSTEM
+                                      ? "^\\/opt\\/minecraft-launcher\\/minecraft-launcher"
+                                      : "\\\\Minecraft Launcher\\\\MinecraftLauncher\\.exe");
   // For the game, we want to specifically match instances of Minecraft launched
   // by the launcher. Luckily the launcher always adds an argument to the
   // command, so we can use that. To cut down on false positives, we also match

--- a/trollauncher/mc_process_detector.cpp
+++ b/trollauncher/mc_process_detector.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 Tim Perkins
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the “Software”), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#include "trollauncher/mc_process_detector.hpp"
+
+#include <iostream>
+#include <regex>
+
+#ifndef ITS_A_UNIX_SYSTEM
+#ifndef _WIN32
+#define ITS_A_UNIX_SYSTEM true
+#else
+#define ITS_A_UNIX_SYSTEM false
+#endif
+#endif
+
+#if ITS_A_UNIX_SYSTEM
+#include <proc/readproc.h>
+#endif
+
+namespace tl {
+
+McProcessRunning McProcessDetector::GetRunningMinecraft()
+{
+#if ITS_A_UNIX_SYSTEM
+  PROCTAB* const proctab_ptr = openproc(PROC_FILLCOM);
+  if (proctab_ptr == nullptr) {
+    // Technically an error, but we will just assume it's not running since
+    // detection is not perfect and best effort only
+    return McProcessRunning::NONE;
+  }
+  // For the launcher, we attempt to match the absolute path of the program,
+  // which *should* be pretty consistent. If the user is doing something
+  // slightly wacky like using a relative path, this will fail. This is still
+  // kind of the best option because matching just "minecraft-launcher" is a bit
+  // generic and might give false positives.
+  const std::regex launcher_regex("^\\/opt\\/minecraft-launcher\\/minecraft-launcher");
+  // For the game, we want to specifically match instances of Minecraft launched
+  // by the launcher. Luckily the launcher always adds an argument to the
+  // command, so we can use that. To cut down on false positives, we also match
+  // the main class, which should always be one of the three listed below.
+  const std::regex game_launch_regex("-Dminecraft\\.launcher\\.brand=minecraft-launcher");
+  const std::regex game_class_regex(
+      "net\\.minecraft\\.client\\.main\\.Main"
+      "|cpw\\.mods\\.modlauncher\\.Launcher"
+      "|net\\.minecraft\\.launchwrapper\\.Launch");
+  bool found_launcher = false;
+  bool found_game = false;
+  proc_t proc_info = {};
+  while ((!found_launcher || !found_game) && readproc(proctab_ptr, &proc_info) != nullptr) {
+    if (proc_info.cmdline == nullptr) {
+      continue;
+    }
+    std::string full_command;
+    {
+      const char* const* cmdline_ptr = proc_info.cmdline;
+      full_command = *cmdline_ptr;
+      while (*++cmdline_ptr != nullptr) {
+        full_command += " ";
+        full_command += *cmdline_ptr;
+      }
+    }
+    if (!found_launcher) {
+      if (std::regex_search(full_command, launcher_regex)) {
+        found_launcher = true;
+        continue;
+      }
+    }
+    if (!found_game) {
+      if (std::regex_search(full_command, game_launch_regex)
+          && std::regex_search(full_command, game_class_regex)) {
+        found_game = true;
+        continue;
+      }
+    }
+  }
+  closeproc(proctab_ptr);
+  return (found_launcher && found_game
+              ? McProcessRunning::LAUNCHER_AND_GAME
+              : (found_launcher ? McProcessRunning::LAUNCHER
+                                : (found_game ? McProcessRunning::GAME : McProcessRunning::NONE)));
+#else
+  // TODO Windows support
+  return McProcessRunning::NONE;
+#endif
+}
+
+}  // namespace tl

--- a/trollauncher/mc_process_detector.hpp
+++ b/trollauncher/mc_process_detector.hpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Tim Perkins
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the “Software”), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#ifndef TROLLAUNCHER_MC_PROCESS_DETECTOR_HPP_
+#define TROLLAUNCHER_MC_PROCESS_DETECTOR_HPP_
+
+namespace tl {
+
+enum class McProcessRunning {
+  NONE,
+  LAUNCHER,
+  GAME,
+  LAUNCHER_AND_GAME,
+};
+
+class McProcessDetector final {
+ public:
+  McProcessDetector() = delete;
+
+  static McProcessRunning GetRunningMinecraft();
+};
+
+}  // namespace tl
+
+#endif  // TROLLAUNCHER_MC_PROCESS_DETECTOR_HPP_


### PR DESCRIPTION
Adds a feature to detect running Minecraft processes and warn the user accordingly.

Having running Minecraft processes is bad because in the case of the launcher, it can cause conflicting writes to the launcher profiles. In the case of the game, the install process can't update or delete files that are already in use (on Windows) and it's just a bad idea in general.

On Linux we use `libprocps` for process detection. On Windows we use Windows Management Instrumentation (WMI).

Closes #9.