### PR TITLE
Continuous integration for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   ubuntu-build:
     name: Ubuntu Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: ${{matrix.container}}
     strategy:
@@ -23,4 +23,22 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: trollauncher_ubuntu
-          path: 'package/ubuntu/trollauncher_*.deb'
+          path: package/ubuntu/trollauncher_*.deb
+  windows-build:
+    name: Windows Build
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - run: docker pull tprk77/trollauncherci:windows2019
+      - run: docker run -v "${PWD}:C:\trollauncher" -w C:\trollauncher
+          tprk77/trollauncherci:windows2019
+          C:\msys64\usr\bin\bash.exe -lc
+          'meson setup --buildtype minsize rbuild
+            && ninja -v -C rbuild
+            && strip -s rbuild/trollauncher.exe'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: trollauncher_windows
+          path: rbuild/trollauncher.exe

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ First install MSYS2, and start the MSYS2 MINGW64 Shell.
 ```text
 $ pacman -Syu
 $ pacman -Syu  # Yes, do it twice!
-$ pacman -S mingw64/mingw-w64-x86_64-toolchain \
-    mingw64/mingw-w64-x86_64-python-pip mingw64/mingw-w64-x86_64-ninja \
-    mingw64/mingw-w64-x86_64-boost mingw64/mingw-w64-x86_64-libzip \
-    mingw64/mingw-w64-x86_64-wxWidgets mingw64/mingw-w64-x86_64-jbigkit
+$ pacman -S mingw-w64-x86_64-toolchain \
+    mingw-w64-x86_64-python-pip mingw-w64-x86_64-ninja \
+    mingw-w64-x86_64-boost mingw-w64-x86_64-libzip \
+    mingw-w64-x86_64-wxWidgets mingw-w64-x86_64-jbigkit
 $ pip3 install meson
 $ cd trollauncher
 $ meson setup build

--- a/ci/containers/README.md
+++ b/ci/containers/README.md
@@ -1,0 +1,31 @@
+# Docker Containers #
+
+## Ubuntu Containers ##
+
+These are easy. Just use Docker like normal.
+
+## Windows Containers ##
+
+These are a pain, and I ran into a few issues getting them to work.
+
+First, I had some weird DNS issues on my machine. To get anything to resolve, I
+had to use the `--dns` argument or change the daemon settings. Not a big deal
+but annoying. FYI, I did not have this issue when I tried it on an Azure VM, so
+it might just be that particular laptop.
+
+Second, I tried using `windows/nanoserver`, but it seemed that MSYS2 didn't
+really work on it. Fortunately, it did work on `windows/servercore`. The
+downside is that it's a 5 GB container! So we better make sure we are building
+off of [GitHub's cached image][gh_windows_img], which is currently
+`windows/servercore:ltsc2019`.
+
+Third, `docker build` would hang and never complete. It turns out it's [getting
+stuck trying to export the layers][docker_hcsshim_issue]. I found a workaround
+that's [a massive hack][docker_msys2_issue], but at least it works. Basically,
+you need to run some random `docker-ci-zap` to unblock the build process.
+
+<!-- Links -->
+
+[gh_windows_img]: https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
+[docker_hcsshim_issue]: https://github.com/microsoft/hcsshim/issues/696
+[docker_msys2_issue]: https://github.com/msys2/MSYS2-packages/issues/2305

--- a/ci/containers/Windows2019Dockerfile
+++ b/ci/containers/Windows2019Dockerfile
@@ -1,0 +1,45 @@
+# tprk77/trollauncherci:windows2019
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ARG MSYS2_INSTALLER_URL=https://github.com/msys2/msys2-installer/releases/download/2020-06-29/msys2-base-x86_64-20200629.sfx.exe
+
+RUN curl -L -o C:\msys2.exe %MSYS2_INSTALLER_URL% \
+    && C:\msys2.exe -y -o"C:\" \
+    && del C:\msys2.exe \
+    && echo DONE -- %DATE% %TIME%
+
+RUN C:\msys64\usr\bin\bash.exe -lc " " \
+    && C:\msys64\usr\bin\bash.exe -lc "pacman -Syuu --noconfirm --noprogressbar" \
+    && C:\msys64\usr\bin\bash.exe -lc "pacman -Syuu --noconfirm --noprogressbar" \
+    && C:\msys64\usr\bin\bash.exe -lc "pacman -Scc --noconfirm" \
+    && echo DONE -- %DATE% %TIME%
+
+ENV MSYSTEM=MINGW64 \
+    CHERE_INVOKING=1
+
+RUN C:\msys64\usr\bin\bash.exe -lc "pacman -S --noconfirm --noprogressbar \
+        git \
+        make \
+        zip" \
+    && C:\msys64\usr\bin\bash.exe -lc "pacman -Scc --noconfirm" \
+    && echo DONE -- %DATE% %TIME%
+
+RUN C:\msys64\usr\bin\bash.exe -lc "pacman -S --noconfirm --noprogressbar \
+        mingw-w64-x86_64-gcc \
+        mingw-w64-x86_64-libtool \
+        mingw-w64-x86_64-python-pip \
+        mingw-w64-x86_64-ninja \
+        mingw-w64-x86_64-cmake \
+        mingw-w64-x86_64-pkg-config \
+        mingw-w64-x86_64-boost \
+        mingw-w64-x86_64-libzip \
+        mingw-w64-x86_64-wxWidgets \
+        mingw-w64-x86_64-jbigkit" \
+    && C:\msys64\usr\bin\bash.exe -lc "pacman -Scc --noconfirm" \
+    && echo DONE -- %DATE% %TIME%
+
+RUN C:\msys64\usr\bin\bash.exe -lc "pip3 install meson==0.55.0" \
+    && echo DONE -- %DATE% %TIME%
+
+CMD ["C:\\msys64\\usr\\bin\\bash.exe", "-l"]


### PR DESCRIPTION
Adds a Windows build to CI. Uses a Windows Docker image `tprk77/trollauncherci:windows2019` which bundles up all the tools and dependencies. The one downside is that it takes a long time (like 10 minutes) just to pull the container. Not sure if that can be sped up at all, I've already tried to minimize the container size.

Fixes #16.